### PR TITLE
Remove get_account_balance()

### DIFF
--- a/texpy/botox.py
+++ b/texpy/botox.py
@@ -28,11 +28,6 @@ def get_client(use_prod: bool = False):
         return boto3.client('mturk', region_name="us-east-1", endpoint_url='https://mturk-requester-sandbox.us-east-1.amazonaws.com')
 
 
-def get_account_balance(conn) -> float:
-    response = conn.get_account_balance()
-    return response['AvailableBalance']
-
-
 # region: qualifications
 def create_qualification(conn, name: str, keywords: str, description: str, auto_granted: bool = True,
                          auto_granted_value: int = 100) -> str:

--- a/texpy/commands.py
+++ b/texpy/commands.py
@@ -123,7 +123,7 @@ def launch_task(exp: ExperimentBatch,
     logger.info(f"We're going to launch {len(inputs)}x{config['MaxAssignments']} tasks {'(really!)' if use_prod else '(in a sandbox)'}")
     logger.info("Using the following qualifications:\n" + yaml.safe_dump(config['Qualifications']))
     logger.info(f"reward=${reward:0.2f}; time={estimated_time}s; rate=${reward_rate:0.2f}")
-    logger.info(f"cost=${total_cost:0.2f}; balance=${float(botox.get_account_balance(conn)):0.2f}")
+    logger.info(f"cost=${total_cost:0.2f}")
 
     if force_user_input("Are you sure you want to launch? ", ["y", "n"]) == "n":
         sys.exit(1)


### PR DESCRIPTION
This commit removes polling AWS for the associated account balance since access is now blocked through an explicit deny in a service control policy, and MTurk no longer runs on prepaid balances. Charges now occur directly with AWS Billing.